### PR TITLE
Fix for issue #6, link to jakarta.ee from theme logo

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
     <div class="row" id="header-row">
       <div class="col-sm-5 col-md-4" id="header-left">
         <div class="wrapper-logo-default">
-          <a title="Jakarta EE: The New Home of Cloud Native Java" href="{{ '/' | absolute_url }}">
+          <a title="Jakarta EE: The New Home of Cloud Native Java" href="https://jakarta.ee/">
             <img width="140" class="logo-eclipse-default img-responsive hidden-xs" src="https://jakarta.ee/images/jakarta/jakarta-ee-logo.svg" alt="Jakarta EE: The New Home of Cloud Native Java" />
           </a>
         </div>


### PR DESCRIPTION
This changes the link for the logo in the top left to go to https://jakarta.ee as opposed to the home page for the project.