### PR TITLE
Issue #7, Remove projects link from breadcrumb navigation

### DIFF
--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -7,9 +7,6 @@
         <li>
           <a href="https://jakarta.ee/">Home</a>
         </li>
-        <li>
-          <a href="https://jakarta.ee/projects/">Projects</a>
-        </li>
         <li class="active">
           <a href="{{ '/' | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a>
         </li>


### PR DESCRIPTION
Signed-off-by: Jonathan Gallimore <jgallimore@tomitribe.com>

This PR temporarily removes the "Projects" link from the breadcrumb navigation.